### PR TITLE
hk-548, add the netcdf 4.7.3. This will fix the filenetCDF-4 memory l…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ hdfeos_dist=HDF-EOS2.19v1.00.tar.Z
 hdf5=hdf5-1.10.5
 hdf5_dist=$(hdf5).tar.bz2
 
-netcdf4=netcdf-c-4.4.1.1
+netcdf4=netcdf-c-4.7.3
 netcdf4_dist=$(netcdf4).tar.gz
 
 fits=cfitsio


### PR DESCRIPTION
…eaking caused by netcdf 4.4.1.

Also update Makefile to use netcdf 4.7.3. Tested at CentOS 7 with BES.