### PR TITLE
Direct io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
 
 stages:
   - name: build
-    if: branch = master OR branch = test-deploy
+    if: branch = master OR branch =~ ^(.*-test-deploy)$
   - name: never
     if: branch = never
 
@@ -121,5 +121,3 @@ deploy:
     on:
       branch: test-deploy
       condition: $ARTIFACT =~ ^ubuntu|centos7|centos-stream8$
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,3 +121,5 @@ deploy:
     on:
       branch: test-deploy
       condition: $ARTIFACT =~ ^ubuntu|centos7|centos-stream8$
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
 
 stages:
   - name: build
-    if: branch = master OR branch =~ ^(.*-test-deploy)$
+    if: branch = master OR branch = test-deploy
   - name: never
     if: branch = never
 

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ hdfeos_dist=HDF-EOS2.19v1.00.tar.Z
 hdf5=hdf5-1.10.10
 hdf5_dist=$(hdf5).tar.bz2
 
-netcdf4=netcdf-c-4.9.0
+netcdf4=netcdf-490-e
 netcdf4_dist=$(netcdf4).tar.gz
 
 fits=cfitsio-3.49


### PR DESCRIPTION
This merge will update netcdf-4.9.0 to include new APIs that support direct IO. All the existing applications should still work since only new APIs are added to the package.