### PR TITLE
Disable automatic GHA for OSX builds

### DIFF
--- a/.github/workflows/.build-osx.yml
+++ b/.github/workflows/.build-osx.yml
@@ -11,8 +11,8 @@ on:
   #     - master
   #     - main
   #     - /^(.*-test-deploy)$/
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
 concurrency:
   # Cancel intermediate builds only on pull requests
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I *think* we don't want to run this all the time, only when manually triggered (in the Actions tab), as we probably don't want to take on the cost of GHA builds? It is currently enabled because we needed that functionality in order to test #82.