### PR TITLE
Add travis test for expected number of built dependencies per OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ jobs:
       - mkdir -p $TRAVIS_BUILD_DIR/package
       - tar -C $HOME -czvf $TRAVIS_BUILD_DIR/package/hyrax-dependencies-build.tar.gz install
       - num_deps_installed=$(find . -name '*-install-stamp' | wc -l)
-      - if [ "$num_deps_installed" != 11 ]; then echo "Unexpected number of dependencies installed; found $num_deps_installed."; fi
-      - make list-built
+      - if [ "$num_deps_installed" != 11 ]; then echo "Unexpected number of dependencies installed; found $num_deps_installed."; exit 1; fi
+      - find . -name '*-install-stamp' | wc -l
 
     # mkdir returns true if the directory already exists. This dir is used in 'before_deploy'.
   - stage: build
@@ -76,8 +76,8 @@ jobs:
       - mkdir -p $TRAVIS_BUILD_DIR/package
       - tar -C $HOME/rocky8/ -czvf $TRAVIS_BUILD_DIR/package/hyrax-dependencies-rocky8-static.tar.gz install
       - num_deps_installed=$(find . -name '*-install-stamp' | wc -l)
-      - if [ "$num_deps_installed" != 10 ]; then echo "Unexpected number of dependencies installed; found $num_deps_installed."; fi
-      - make list-built
+      - if [ "$num_deps_installed" != 10 ]; then echo "Unexpected number of dependencies installed; found $num_deps_installed."; exit 1; fi
+      - find . -name '*-install-stamp' | wc -l
 
 deploy:
   - provider: s3


### PR DESCRIPTION
Based on test added to GHA in #83, added similar test to freeze the number of expected dependencies we're building, so that we don't accidentally stop building a dependency without realizing it.

Right now, we build 11 for ubuntu-focal [1] and 10 for rocky8 [2], which is reflected in the added test. If this is incorrect, and we should be building more deps on either OS, we can file follow-up issues for those; in the issue itself, when we build/support the dependencies, we can increment the number of dependencies expected.

[1] ubuntu-focal:
```
*** Packages built and installed ***
aws_cdk-install-stamp
bison-install-stamp
gridfields-install-stamp
hdf4-install-stamp
hdf5-install-stamp
hdfeos-install-stamp
jpeg-install-stamp
netcdf4-install-stamp
openjpeg-install-stamp
proj-install-stamp
stare-install-stamp
```
Looks like we're (intentionally?) missing: gdal

[2] rocky8:
```
*** Packages built and installed ***
aws_cdk-install-stamp
bison-install-stamp
gridfields-install-stamp
hdf4-install-stamp
hdf5-install-stamp
hdfeos-install-stamp
jpeg-install-stamp
netcdf4-install-stamp
openjpeg-install-stamp
stare-install-stamp
```
Looks like we're (intentionally?) missing: proj, gdal