### PR TITLE
Add CPPFLAGS to custom netcdf4 cppflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 #
 # Major.Minor.Patch
 
-VERSION = 1.66.0
+VERSION = 1.66.1
 
 # Uncomment this to include a site-specific set of Makefile lines
 # include site.mk

--- a/Makefile
+++ b/Makefile
@@ -647,7 +647,7 @@ $(netcdf4_src)-stamp:
 
 netcdf4-configure-stamp:  $(netcdf4_src)-stamp
 	(cd $(netcdf4_src) && ./configure $(CONFIGURE_FLAGS) $(defaults) \
-	--prefix=$(netcdf4_prefix) CPPFLAGS=-I$(hdf5_prefix)/include	\
+	--prefix=$(netcdf4_prefix) CPPFLAGS="$(CPPFLAGS) -I$(hdf5_prefix)/include" \
 	CFLAGS="-fPIC -O2" LDFLAGS="$(LDFLAGS) -L$(hdf5_prefix)/lib -Wl,-rpath,$(hdf5_prefix)/lib")
 	echo timestamp > netcdf4-configure-stamp
 


### PR DESCRIPTION
## Description

Fixes otherwise broken netcdf4 build on macos m4.

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] `VERSION` in Makefile updated appropriately
- [ ] Relevant ticket or issue exists and is linked in title
- [x] Dead code removed/No TODOs added
