### PR TITLE
Renamed .build-osx.yml to build-osx.yml; removed mac intel build

### DIFF
--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -30,9 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          # See https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md for pre-installed software
           - macos-15
-          - macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

HYRAX-2119

Remove macos-15-intel from the CDCI workflow

## Tasks
<!-- Ignore or delete any irrelevant items -->
- [x] `VERSION` in Makefile updated appropriately
- [x] Relevant ticket or issue exists and is linked in title
- [x] Dead code removed/No TODOs added
